### PR TITLE
Improve dataset handling and training workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rutooro-English Machine Translation
 
-This repository fine-tunes the `facebook/nllb-200-distilled-600M` model on a small English↔Rutooro corpus (~16k sentence pairs).
+This repository fine-tunes the `facebook/nllb-200-distilled-600M` model on an English↔Rutooro corpus.
 
 ## Structure
 
@@ -13,16 +13,42 @@ This repository fine-tunes the `facebook/nllb-200-distilled-600M` model on a sma
 ├── models/                # config / trained model
 ```
 
-## Usage
+## Getting the data
 
-1. Install dependencies
-   ```bash
-   pip install -r requirements.txt
-   ```
-2. Run preprocessing or evaluation scripts in `scripts/`.
-3. Launch the Gradio demo:
-   ```bash
-   python app/gradio_demo.py
-   ```
+Install dependencies first:
 
-See `notebooks/train_nllb_colab.ipynb` for a full training pipeline on Google Colab.
+```bash
+pip install -r requirements.txt
+```
+
+Download the raw parallel corpus from HuggingFace or MaNy-Eng and convert it to JSON:
+
+```bash
+python scripts/download_dataset.py --source hf --output data/english_rutooro.json
+```
+
+Clean the data and create train/dev/test splits (files will be written to `data/clean/`):
+
+```bash
+python scripts/preprocess.py data/english_rutooro.json data/clean
+```
+
+## Training
+
+Open `notebooks/train_nllb_colab.ipynb` in Google Colab. The notebook checks GPU availability, enables mixed precision training and uses early stopping. Upload the files from `data/clean/` and run the cells to fine-tune the model.
+
+## Demo
+
+Launch a small Gradio interface to test the trained model locally:
+
+```bash
+python app/gradio_demo.py
+```
+
+## Sample translations
+
+| English | Rutooro |
+|---------|---------|
+| "How are you?" | "Oraire ota?" |
+| "Thank you" | "Webale" |
+

--- a/app/gradio_demo.py
+++ b/app/gradio_demo.py
@@ -25,11 +25,22 @@ def translate(text, direction):
 
 
 def main():
+    """Launch the interactive translation demo."""
+
+    examples = [
+        ["How are you?", "en-ttj"],
+        ["Oraire ota?", "ttj-en"],
+    ]
+
     iface = gr.Interface(
         fn=translate,
-        inputs=[gr.Textbox(lines=3, label="Input"), gr.Radio(["en-ttj", "ttj-en"], value="en-ttj", label="Direction")],
-        outputs=gr.Textbox(label="Translation"),
+        inputs=[
+            gr.Textbox(lines=3, label="Input Text"),
+            gr.Radio(["en-ttj", "ttj-en"], value="en-ttj", label="Direction (English→Rutooro or vice versa)")
+        ],
+        outputs=gr.Textbox(label="Translated Text"),
         title="Rutooro-English Translator",
+        examples=examples,
     )
     iface.launch()
 

--- a/notebooks/train_nllb_colab.ipynb
+++ b/notebooks/train_nllb_colab.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Fine-tune NLLB-200 on Rutooro\n",
-    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English↔Rutooro translation."
+    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English\u2194Rutooro translation."
    ]
   },
   {
@@ -29,6 +29,16 @@
     "from datasets import load_dataset\n",
     "from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, DataCollatorForSeq2Seq, Seq2SeqTrainer, Seq2SeqTrainingArguments\n",
     "from evaluate import load as load_metric"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "print('GPU available:', torch.cuda.is_available())"
    ]
   },
   {
@@ -92,6 +102,8 @@
     "    num_train_epochs=5,\n",
     "    save_total_limit=2,\n",
     "    predict_with_generate=True,\n",
+    "    fp16=True,\n",
+    "    load_best_model_at_end=True,\n",
     ")\n",
     "\n",
     "data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)\n",
@@ -105,6 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from transformers import EarlyStoppingCallback\n",
     "def compute_metrics(eval_preds):\n",
     "    preds, labels = eval_preds\n",
     "    if isinstance(preds, tuple):\n",
@@ -115,7 +128,7 @@
     "    bleu = metric.compute(predictions=decoded_preds, references=[[l] for l in decoded_labels])\n",
     "    return {\"bleu\": bleu[\"score\"]}\n",
     "\n",
-    "trainer = Seq2SeqTrainer(model=model, args=args, train_dataset=processed, eval_dataset=processed, data_collator=data_collator, tokenizer=tokenizer, compute_metrics=compute_metrics)"
+    "trainer = Seq2SeqTrainer(model=model, args=args, train_dataset=processed, eval_dataset=processed, data_collator=data_collator, tokenizer=tokenizer, compute_metrics=compute_metrics, callbacks=[EarlyStoppingCallback(early_stopping_patience=3)])"
    ]
   },
   {

--- a/scripts/download_dataset.py
+++ b/scripts/download_dataset.py
@@ -1,21 +1,101 @@
-"""Download English-Rutooro dataset from HuggingFace and save as JSON."""
-from datasets import load_dataset
+
+"""Download English↔Rutooro datasets and convert to a unified JSON format.
+
+Two sources are supported:
+ - The small dataset hosted on HuggingFace under
+   ``michsethowusu/english-tooro_sentence-pairs_mt560``.
+ - The MaNy-Eng collection available from
+   https://rtg.isi.edu/many-eng/data-v1.html.
+
+The resulting file is a list of dictionaries following the structure used by
+``datasets.load_dataset(..., 'json')`` where each entry is of the form::
+
+    {"translation": {"en": "english text", "ttj": "rutooro text"}}
+
+The script only performs downloading/formatting so that downstream
+preprocessing can operate on a single consistent file.
+"""
+
+from __future__ import annotations
+
+import argparse
 import json
+import logging
 from pathlib import Path
+from typing import List
 
-DATASET_NAME = "michsethowusu/english-tooro_sentence-pairs_mt560"
+import requests
+from datasets import load_dataset
+
+HF_DATASET = "michsethowusu/english-tooro_sentence-pairs_mt560"
 
 
-def main(output_path: str = "data/english_rutooro.json"):
-    ds = load_dataset(DATASET_NAME, split="train")
+def load_from_hf() -> List[dict]:
+    """Load dataset from the HuggingFace Hub."""
+    ds = load_dataset(HF_DATASET, split="train")
     pairs = []
     for row in ds:
         en = row.get("english") or row.get("source")
         tt = row.get("rutooro") or row.get("target")
         if en and tt:
             pairs.append({"translation": {"en": en, "ttj": tt}})
-    Path(output_path).write_text(json.dumps(pairs, ensure_ascii=False, indent=2), encoding="utf-8")
+    return pairs
+
+
+def load_from_many_eng() -> List[dict]:
+    """Attempt to download the Rutooro–English data from MaNy-Eng.
+
+    The dataset webpage lists several tarballs for each language pair.  We use a
+    small helper that tries to fetch ``ttj-eng-v1.tar.gz`` (the naming used on
+    release ``data-v1.html``).  If the download fails an informative error is
+    raised so users know they may have to retrieve the data manually.
+    """
+
+    url = (
+        "https://rtg.isi.edu/many-eng/releases/many-eng-v1.0/ttj-eng-v1.tsv"
+    )
+    logging.info("Downloading MaNy-Eng dataset from %s", url)
+    resp = requests.get(url)
+    if resp.status_code != 200:
+        raise RuntimeError(
+            f"Failed to download dataset (status code {resp.status_code})."
+        )
+
+    pairs = []
+    for line in resp.text.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            en, tt = parts[0], parts[1]
+            pairs.append({"translation": {"en": en, "ttj": tt}})
+    return pairs
+
+
+def main(output_path: str = "data/english_rutooro.json", source: str = "hf"):
+    if source == "hf":
+        pairs = load_from_hf()
+    elif source == "many-eng":
+        pairs = load_from_many_eng()
+    else:
+        raise ValueError("source must be 'hf' or 'many-eng'")
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(output_path).write_text(
+        json.dumps(pairs, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        default="data/english_rutooro.json",
+        help="Where to write the unified JSON file",
+    )
+    parser.add_argument(
+        "--source",
+        choices=["hf", "many-eng"],
+        default="hf",
+        help="Dataset source to download",
+    )
+    args = parser.parse_args()
+    main(args.output, args.source)

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,29 +1,51 @@
-"""Evaluate translation model with sacreBLEU and chrF++"""
+"""Evaluate translation outputs using BLEU and chrF++ metrics."""
+
+from __future__ import annotations
+
 import argparse
 from pathlib import Path
+from typing import Tuple
 
-from datasets import load_metric
-from sacrebleu.metrics import CHRF
+import evaluate
 
 
-def compute_metrics(pred_file: str, ref_file: str):
-    preds = [line.strip() for line in Path(pred_file).read_text(encoding='utf-8').splitlines()]
-    refs = [line.strip() for line in Path(ref_file).read_text(encoding='utf-8').splitlines()]
-    bleu = load_metric('bleu')
-    bleu_result = bleu.compute(predictions=preds, references=[[r] for r in refs])
-    chrf = CHRF()
-    chrf_result = chrf.corpus_score(preds, [refs])
-    return bleu_result['bleu'], chrf_result.score
+def _load_lines(path: str) -> list[str]:
+    return [l.strip() for l in Path(path).read_text(encoding="utf-8").splitlines()]
+
+
+def compute_metrics(pred_file: str, ref_file: str) -> Tuple[float, float]:
+    """Return corpus BLEU and chrF++ scores for the given files."""
+
+    preds = _load_lines(pred_file)
+    refs = _load_lines(ref_file)
+
+    bleu_metric = evaluate.load("sacrebleu")
+    chrf_metric = evaluate.load("chrf")
+
+    bleu = bleu_metric.compute(predictions=preds, references=[[r] for r in refs])["score"]
+    chrf = chrf_metric.compute(predictions=preds, references=refs)["score"]
+
+    return bleu, chrf
+
+
+def print_samples(pred_file: str, ref_file: str, num: int = 3) -> None:
+    preds = _load_lines(pred_file)[:num]
+    refs = _load_lines(ref_file)[:num]
+    for i, (p, r) in enumerate(zip(preds, refs), 1):
+        print(f"[{i}]\n  REF: {r}\n  HYP: {p}\n")
 
 
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('pred', help='Predictions file')
     parser.add_argument('ref', help='Reference file')
+    parser.add_argument('--samples', type=int, default=3, help='Number of example translations to display')
     args = parser.parse_args()
     bleu, chrf_score = compute_metrics(args.pred, args.ref)
     print(f"BLEU: {bleu:.2f}")
-    print(f"chrF++: {chrf_score:.2f}")
+    print(f"chrF++: {chrf_score:.2f}\n")
+
+    print_samples(args.pred, args.ref, args.samples)
 
 
 if __name__ == '__main__':

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -1,26 +1,103 @@
-"""Preprocess dataset for Rutooro-English translation."""
-import json
+
+"""Clean and split the dataset for training.
+
+The input is expected to be a list of dictionaries containing a ``translation``
+field.  Text is normalised by lowercasing and removing characters outside the
+basic Latin alphabet and punctuation. Duplicate or empty pairs are discarded and
+the final result is written to ``train.json``, ``dev.json`` and ``test.json``
+inside the given output directory.
+"""
+
+from __future__ import annotations
+
 import argparse
+import json
+import random
+import re
 from pathlib import Path
+from typing import List, Tuple
 
 
-def preprocess(input_path: str, output_path: str):
-    """Load dataset from json (list of {\"translation\":{\"en\":...,\"tt\":...}}) and save parallel pairs."""
-    data = []
-    with open(input_path, 'r', encoding='utf-8') as f:
-        dataset = json.load(f)
-    for row in dataset:
-        if 'translation' in row:
-            en = row['translation'].get('english') or row['translation'].get('en')
-            tt = row['translation'].get('rutooro') or row['translation'].get('ttj') or row['translation'].get('tt')
-            if en and tt:
-                data.append({'translation': {'en': en, 'ttj': tt}})
-    Path(output_path).write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding='utf-8')
+_CLEAN_RE = re.compile(r"[^a-z0-9\s.,!?\-']+")
 
 
-if __name__ == '__main__':
+def _clean(text: str) -> str:
+    text = text.lower()
+    text = _CLEAN_RE.sub("", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text
+
+
+def preprocess(input_path: str) -> List[Tuple[str, str]]:
+    """Read and clean raw data returning a list of sentence pairs."""
+
+    with open(input_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+
+    pairs = []
+    seen = set()
+    for row in raw:
+        if "translation" not in row:
+            continue
+        en = row["translation"].get("en") or row["translation"].get("english")
+        tt = (
+            row["translation"].get("ttj")
+            or row["translation"].get("rutooro")
+            or row["translation"].get("tt")
+        )
+        if not en or not tt:
+            continue
+        en_c = _clean(en)
+        tt_c = _clean(tt)
+        if not en_c or not tt_c:
+            continue
+        key = (en_c, tt_c)
+        if key not in seen:
+            seen.add(key)
+            pairs.append(key)
+
+    return pairs
+
+
+def split_and_save(pairs: List[Tuple[str, str]], output_dir: str) -> None:
+    """Split data and write ``train.json``, ``dev.json`` and ``test.json``."""
+
+    random.shuffle(pairs)
+    n = len(pairs)
+    train_end = int(n * 0.8)
+    dev_end = int(n * 0.9)
+
+    splits = {
+        "train": pairs[:train_end],
+        "dev": pairs[train_end:dev_end],
+        "test": pairs[dev_end:],
+    }
+
+    out_dir = Path(output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name, subset in splits.items():
+        data = [
+            {"translation": {"en": en, "ttj": tt}}
+            for en, tt in subset
+        ]
+        (out_dir / f"{name}.json").write_text(
+            json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+
+
+def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('input', help='Input JSON file')
-    parser.add_argument('output', help='Output cleaned JSON file')
+    parser.add_argument("input", help="Raw JSON file produced by download script")
+    parser.add_argument(
+        "output_dir",
+        default="data/clean",
+        help="Directory to store train/dev/test JSON files",
+    )
     args = parser.parse_args()
-    preprocess(args.input, args.output)
+
+    pairs = preprocess(args.input)
+    split_and_save(pairs, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add automation for dataset download from HuggingFace or MaNy‑Eng
- implement robust dataset preprocessing and splitting
- add BLEU and chrF++ evaluation metrics with sample outputs
- improve Gradio demo labelling and add examples
- enhance training notebook with GPU check, fp16, and early stopping
- document data prep, training and demo usage in the README

## Testing
- `python -m py_compile scripts/download_dataset.py scripts/preprocess.py scripts/evaluate.py app/gradio_demo.py`


------
https://chatgpt.com/codex/tasks/task_e_68872ce153c8832b92f848a33be347fe