### PR TITLE
Improve Colab training notebook

### DIFF
--- a/notebooks/train_nllb_colab.ipynb
+++ b/notebooks/train_nllb_colab.ipynb
@@ -6,96 +6,186 @@
    "metadata": {},
    "source": [
     "# Fine-tune NLLB-200 on Rutooro\n",
-    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English\u2194Rutooro translation."
+    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English↔Rutooro translation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23f4a19d",
+   "metadata": {},
+   "source": [
+    "## Setup: Clone the repository"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42e799da",
+   "id": "48fe2476",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q transformers datasets evaluate sacrebleu gradio"
+    "# Clone latest repo version for runtime usage\n",
+    "!git clone https://github.com/nyacly/rutooro-mt-model.git\n",
+    "%cd rutooro-mt-model\n",
+    "!git pull origin main\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f65c4c2",
+   "metadata": {},
+   "source": [
+    "## Optional: Mount Google Drive"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cbe7fcdd",
+   "id": "374749ca",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# OPTIONAL: Mount Google Drive if you want to save training results\n",
+    "from google.colab import drive\n",
+    "drive.mount('/content/drive')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "260ba40e",
+   "metadata": {},
+   "source": [
+    "## Install dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e935282",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install all required dependencies\n",
+    "!pip install transformers datasets evaluate gradio sacrebleu\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23d3cd9f",
+   "metadata": {},
+   "source": [
+    "## Check GPU availability"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33d3199d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch\n",
+    "print('GPU available:', torch.cuda.is_available())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18d69b1e",
+   "metadata": {},
+   "source": [
+    "## Load and preprocess the dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98cfc48b",
    "metadata": {},
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
     "from transformers import AutoTokenizer, AutoModelForSeq2SeqLM, DataCollatorForSeq2Seq, Seq2SeqTrainer, Seq2SeqTrainingArguments\n",
-    "from evaluate import load as load_metric"
+    "from evaluate import load as load_metric\n",
+    "\n",
+    "dataset = load_dataset('michsethowusu/english-tooro_sentence-pairs_mt560')['train']\n",
+    "# Split 80:10:10\n",
+    "splits = dataset.train_test_split(test_size=0.2, seed=42)\n",
+    "val_test = splits['test'].train_test_split(test_size=0.5, seed=42)\n",
+    "train_ds = splits['train']\n",
+    "val_ds = val_test['train']\n",
+    "test_ds = val_test['test']\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "73c51db0",
+   "metadata": {},
+   "source": [
+    "## Initialize model and tokenizer"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "7ac8c660",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
-    "print('GPU available:', torch.cuda.is_available())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "25ba4438",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dataset = load_dataset(\"michsethowusu/english-tooro_sentence-pairs_mt560\")\n",
-    "train_ds = dataset[\"train\"]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1f915c51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_name = \"facebook/nllb-200-distilled-600M\"\n",
+    "model_name = 'facebook/nllb-200-distilled-600M'\n",
     "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
     "model = AutoModelForSeq2SeqLM.from_pretrained(model_name)\n",
     "\n",
-    "tokenizer.src_lang = \"eng_Latn\"\n",
-    "tokenizer.tgt_lang = \"ttj_Latn\""
+    "tokenizer.src_lang = 'eng_Latn'\n",
+    "tokenizer.tgt_lang = 'ttj_Latn'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad74d1b8",
+   "metadata": {},
+   "source": [
+    "### Tokenization helper"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26735798",
+   "id": "189325d8",
    "metadata": {},
    "outputs": [],
    "source": [
     "def preprocess(example):\n",
-    "    inputs = example[\"english\"]\n",
-    "    targets = example[\"rutooro\"]\n",
+    "    inputs = example['english']\n",
+    "    targets = example['rutooro']\n",
     "    model_inputs = tokenizer(inputs, truncation=True)\n",
     "    with tokenizer.as_target_tokenizer():\n",
     "        labels = tokenizer(targets, truncation=True)\n",
-    "    model_inputs[\"labels\"] = labels[\"input_ids\"]\n",
+    "    model_inputs['labels'] = labels['input_ids']\n",
     "    return model_inputs\n",
     "\n",
-    "processed = train_ds.map(preprocess, batched=True)"
+    "train_enc = train_ds.map(preprocess, batched=True)\n",
+    "val_enc = val_ds.map(preprocess, batched=True)\n",
+    "test_enc = test_ds.map(preprocess, batched=True)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04fc3e70",
+   "metadata": {},
+   "source": [
+    "## Training setup"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d36a53ae",
+   "id": "39ab3a26",
    "metadata": {},
    "outputs": [],
    "source": [
     "args = Seq2SeqTrainingArguments(\n",
-    "    output_dir=\"./model\",\n",
-    "    evaluation_strategy=\"epoch\",\n",
+    "    output_dir='./model',\n",
+    "    evaluation_strategy='epoch',\n",
     "    learning_rate=2e-5,\n",
     "    per_device_train_batch_size=8,\n",
     "    per_device_eval_batch_size=8,\n",
@@ -107,17 +197,26 @@
     ")\n",
     "\n",
     "data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)\n",
-    "metric = load_metric(\"sacrebleu\")"
+    "metric = load_metric('sacrebleu')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94216fa8",
+   "metadata": {},
+   "source": [
+    "## Train and evaluate"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffa5cbaa",
+   "id": "45434c49",
    "metadata": {},
    "outputs": [],
    "source": [
     "from transformers import EarlyStoppingCallback\n",
+    "\n",
     "def compute_metrics(eval_preds):\n",
     "    preds, labels = eval_preds\n",
     "    if isinstance(preds, tuple):\n",
@@ -126,15 +225,32 @@
     "    labels = [[(l if l != -100 else tokenizer.pad_token_id) for l in label] for label in labels]\n",
     "    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)\n",
     "    bleu = metric.compute(predictions=decoded_preds, references=[[l] for l in decoded_labels])\n",
-    "    return {\"bleu\": bleu[\"score\"]}\n",
+    "    return {'bleu': bleu['score']}\n",
     "\n",
-    "trainer = Seq2SeqTrainer(model=model, args=args, train_dataset=processed, eval_dataset=processed, data_collator=data_collator, tokenizer=tokenizer, compute_metrics=compute_metrics, callbacks=[EarlyStoppingCallback(early_stopping_patience=3)])"
+    "trainer = Seq2SeqTrainer(\n",
+    "    model=model,\n",
+    "    args=args,\n",
+    "    train_dataset=train_enc,\n",
+    "    eval_dataset=val_enc,\n",
+    "    data_collator=data_collator,\n",
+    "    tokenizer=tokenizer,\n",
+    "    compute_metrics=compute_metrics,\n",
+    "    callbacks=[EarlyStoppingCallback(early_stopping_patience=3)]\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d88699f7",
+   "metadata": {},
+   "source": [
+    "### Start training"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6812821b",
+   "id": "e07dc048",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,27 +258,52 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6013937",
+   "cell_type": "markdown",
+   "id": "71208cd2",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "trainer.save_model(\"./model\")"
+    "## Save the model"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d36b58b",
+   "id": "42b22d68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainer.save_model('./model')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1c8ff14e",
+   "metadata": {},
+   "source": [
+    "## Run the Gradio demo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fcad8bb2",
    "metadata": {},
    "outputs": [],
    "source": [
     "import gradio as gr\n",
     "from app.gradio_demo import translate\n",
     "\n",
-    "iface = gr.Interface(fn=lambda txt: translate(txt, \"en-ttj\"), inputs=\"text\", outputs=\"text\")\n",
-    "iface.launch()"
+    "iface = gr.Interface(fn=lambda txt: translate(txt, 'en-ttj'), inputs='text', outputs='text')\n",
+    "iface.launch()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5eab3bf2",
+   "metadata": {},
+   "source": [
+    "### Next steps\n",
+    "You can now use the saved model in `./model` or run the demo above to interactively translate between English and Rutooro."
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- add repository clone step to run notebook directly from GitHub
- provide optional Google Drive mounting cell
- install required dependencies and check GPU
- load and split dataset 80/10/10 and preprocess splits
- clarify training pipeline and add instructions to run demo

## Testing
- `nbformat` load/save to ensure notebook validity

------
https://chatgpt.com/codex/tasks/task_e_688752416ffc832bb427bbcadc78541f