### PR TITLE
Add Google Drive persistence for Colab training

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,17 @@ python scripts/preprocess.py data/english_rutooro.json data/clean
 
 ## Training
 
-Open `notebooks/train_nllb_colab.ipynb` in Google Colab. The notebook checks GPU availability, enables mixed precision training and uses early stopping. Upload the files from `data/clean/` and run the cells to fine-tune the model.
+Open `notebooks/train_nllb_colab.ipynb` in Google Colab. The notebook checks GPU availability, enables mixed precision training and uses early stopping. Mount your Google Drive when prompted so training data and checkpoints are stored persistently.
+
+After mounting, the notebook creates the following folders in your Drive:
+
+```
+/content/drive/MyDrive/rutooro-mt-data/    # datasets
+/content/drive/MyDrive/rutooro-mt-models/  # model checkpoints
+/content/drive/MyDrive/rutooro-mt-outputs/ # logs and metrics
+```
+
+Prepared datasets, checkpoints and final models will be saved here so you can resume training or run the demo without reprocessing.
 
 ## Demo
 

--- a/notebooks/train_nllb_colab.ipynb
+++ b/notebooks/train_nllb_colab.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Fine-tune NLLB-200 on Rutooro\n",
-    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English↔Rutooro translation."
+    "This Colab notebook demonstrates how to fine-tune `facebook/nllb-200-distilled-600M` for English\u2194Rutooro translation."
    ]
   },
   {
@@ -35,7 +35,7 @@
    "id": "9f65c4c2",
    "metadata": {},
    "source": [
-    "## Optional: Mount Google Drive"
+    "## Mount Google Drive and set up folders"
    ]
   },
   {
@@ -45,9 +45,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# OPTIONAL: Mount Google Drive if you want to save training results\n",
+    "# Mount Google Drive for persistent storage\n",
     "from google.colab import drive\n",
-    "drive.mount('/content/drive')\n"
+    "drive.mount('/content/drive')\n",
+    "\n",
+    "import os\n",
+    "data_dir = '/content/drive/MyDrive/rutooro-mt-data'\n",
+    "model_dir = '/content/drive/MyDrive/rutooro-mt-models'\n",
+    "output_dir = '/content/drive/MyDrive/rutooro-mt-outputs'\n",
+    "for d in [data_dir, model_dir, output_dir]:\n",
+    "    os.makedirs(d, exist_ok=True)\n",
+    "print('Data directory:', data_dir)\n",
+    "print('Model directory:', model_dir)\n",
+    "print('Output directory:', output_dir)\n"
    ]
   },
   {
@@ -170,6 +180,25 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save datasets to Google Drive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Store processed datasets for later reuse\n",
+    "train_enc.save_to_disk(f'{data_dir}/train_enc')\n",
+    "val_enc.save_to_disk(f'{data_dir}/val_enc')\n",
+    "test_enc.save_to_disk(f'{data_dir}/test_enc')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "04fc3e70",
    "metadata": {},
    "source": [
@@ -184,7 +213,7 @@
    "outputs": [],
    "source": [
     "args = Seq2SeqTrainingArguments(\n",
-    "    output_dir='./model',\n",
+    "    output_dir=model_dir,\n",
     "    evaluation_strategy='epoch',\n",
     "    learning_rate=2e-5,\n",
     "    per_device_train_batch_size=8,\n",
@@ -272,7 +301,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainer.save_model('./model')"
+    "trainer.save_model(model_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load model from Google Drive"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "from transformers import AutoModelForSeq2SeqLM, AutoTokenizer\n",
+    "model = AutoModelForSeq2SeqLM.from_pretrained(model_dir)\n",
+    "tokenizer = AutoTokenizer.from_pretrained(model_dir)\n"
    ]
   },
   {
@@ -291,8 +338,9 @@
    "outputs": [],
    "source": [
     "import gradio as gr\n",
+    "import app.gradio_demo as demo\n",
+    "demo.MODEL_DIR = model_dir\n",
     "from app.gradio_demo import translate\n",
-    "\n",
     "iface = gr.Interface(fn=lambda txt: translate(txt, 'en-ttj'), inputs='text', outputs='text')\n",
     "iface.launch()\n"
    ]


### PR DESCRIPTION
## Summary
- mount Google Drive when training and create data/model/output folders
- persist processed datasets and checkpoints to Drive
- reload models from Drive for inference
- document Google Drive locations in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: line too long in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_688753d35174832bb5ddd641b07c0169