### PR TITLE
Add model export and download steps to training notebook

### DIFF
--- a/notebooks/train_nllb_colab.ipynb
+++ b/notebooks/train_nllb_colab.ipynb
@@ -1,313 +1,352 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "fd9e9bd8",
-   "metadata": {},
-   "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nyacly/rutooro-mt-model/blob/main/notebooks/train_nllb_colab.ipynb)"
-   ]
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "fd9e9bd8",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/nyacly/rutooro-mt-model/blob/main/notebooks/train_nllb_colab.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "id": "32748a9f",
+      "metadata": {},
+      "source": [
+        "# NLLB-200 Tooro-English Fine-tuning\n",
+        "This notebook trains `facebook/nllb-200-distilled-600M` for Tooro\u2194English translation using the HuggingFace ecosystem. Each step prints useful info to help with debugging."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "db7d0fd3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Install required libraries\n",
+        "!pip install -U transformers datasets evaluate sacrebleu > /dev/null\n",
+        "print('Installed libraries.')\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8ad9ac73",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from google.colab import drive\n",
+        "\n",
+        "# Mount drive for persistent storage\n",
+        "try:\n",
+        "    drive.mount('/content/drive')\n",
+        "except Exception as e:\n",
+        "    print('Drive mount failed:', e)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "adeaba1e",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from pathlib import Path\n",
+        "\n",
+        "data_dir = Path('/content/drive/MyDrive/rutooro-mt-data')\n",
+        "model_dir = Path('/content/drive/MyDrive/rutooro-mt-models')\n",
+        "output_dir = Path('/content/drive/MyDrive/rutooro-mt-outputs')\n",
+        "\n",
+        "for p in [data_dir, model_dir, output_dir]:\n",
+        "    p.mkdir(parents=True, exist_ok=True)\n",
+        "\n",
+        "print('Data directory:', data_dir)\n",
+        "print('Model directory:', model_dir)\n",
+        "print('Output directory:', output_dir)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "b0741f2d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from datasets import load_dataset\n",
+        "\n",
+        "try:\n",
+        "    raw_ds = load_dataset('michsethowusu/english-tooro_sentence-pairs_mt560')\n",
+        "    print('Loaded dataset from HuggingFace.')\n",
+        "except Exception as e:\n",
+        "    print('Failed to load from Hub:', e)\n",
+        "    local_path = data_dir / 'english_rutooro.json'\n",
+        "    if local_path.exists():\n",
+        "        raw_ds = load_dataset('json', data_files=str(local_path))\n",
+        "        print('Loaded dataset from', local_path)\n",
+        "    else:\n",
+        "        raise RuntimeError('Dataset not found. Please upload the data.')\n",
+        "\n",
+        "print(raw_ds)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "22ca0fa3",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Ensure train/val/test splits exist\n",
+        "if 'train' not in raw_ds:\n",
+        "    raw_ds = raw_ds['train'].train_test_split(test_size=0.2)\n",
+        "    raw_ds['validation'] = raw_ds['test'].train_test_split(test_size=0.5)['test']\n",
+        "    raw_ds['test'] = raw_ds['test'].train_test_split(test_size=0.5)['train']\n",
+        "print(raw_ds)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "30f76e5b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "# Map possible column names to 'eng' and 'ttj'\n",
+        "def map_columns(example):\n",
+        "    en = example.get('english') or example.get('source') or example.get('eng')\n",
+        "    tt = example.get('rutooro') or example.get('target') or example.get('ttj') or example.get('tt')\n",
+        "    return {'eng': en, 'ttj': tt}\n",
+        "\n",
+        "raw_ds = raw_ds.map(map_columns, remove_columns=raw_ds['train'].column_names)\n",
+        "\n",
+        "# Filter out empty rows\n",
+        "raw_ds = raw_ds.filter(lambda x: x['eng'] and x['ttj'])\n",
+        "\n",
+        "print('After filtering:', raw_ds)\n",
+        "print('Sample:', raw_ds['train'][0])\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "94832844",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from transformers import AutoTokenizer, AutoModelForSeq2SeqLM\n",
+        "\n",
+        "model_name = 'facebook/nllb-200-distilled-600M'\n",
+        "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
+        "model = AutoModelForSeq2SeqLM.from_pretrained(model_name)\n",
+        "\n",
+        "print('Tokenizer language codes:', tokenizer.lang_code_to_id.get('eng_Latn'), tokenizer.lang_code_to_id.get('ttj_Latn'))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "59dcb6d2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "max_length = 128\n",
+        "\n",
+        "def preprocess(example):\n",
+        "    if isinstance(example['eng'], list):\n",
+        "        eng = example['eng']\n",
+        "        ttj = example['ttj']\n",
+        "    else:\n",
+        "        eng = [example['eng']]\n",
+        "        ttj = [example['ttj']]\n",
+        "\n",
+        "    tokenizer.src_lang = 'eng_Latn'\n",
+        "    tokenizer.tgt_lang = 'ttj_Latn'\n",
+        "\n",
+        "    model_inputs = tokenizer(eng, text_target=ttj, max_length=max_length, truncation=True)\n",
+        "    return model_inputs\n",
+        "\n",
+        "processed_ds = raw_ds.map(preprocess, batched=True)\n",
+        "\n",
+        "print(processed_ds)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "09df16df",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from transformers import DataCollatorForSeq2Seq\n",
+        "\n",
+        "data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "bb513e5b",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from transformers import Seq2SeqTrainingArguments\n",
+        "\n",
+        "training_args = Seq2SeqTrainingArguments(\n",
+        "    output_dir=str(output_dir),\n",
+        "    evaluation_strategy='epoch',\n",
+        "    save_strategy='epoch',\n",
+        "    learning_rate=2e-5,\n",
+        "    per_device_train_batch_size=4,\n",
+        "    per_device_eval_batch_size=4,\n",
+        "    num_train_epochs=3,\n",
+        "    weight_decay=0.01,\n",
+        "    logging_dir=str(output_dir / 'logs'),\n",
+        "    predict_with_generate=True,\n",
+        "    remove_unused_columns=False,\n",
+        ")\n",
+        "print(training_args)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "f082de9d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "import evaluate\n",
+        "\n",
+        "bleu = evaluate.load('sacrebleu')\n",
+        "chrf = evaluate.load('chrf')\n",
+        "\n",
+        "def compute_metrics(eval_preds):\n",
+        "    preds, labels = eval_preds\n",
+        "    if isinstance(preds, tuple):\n",
+        "        preds = preds[0]\n",
+        "    decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)\n",
+        "    labels = [[(l if l != -100 else tokenizer.pad_token_id) for l in label] for label in labels]\n",
+        "    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)\n",
+        "    bleu_score = bleu.compute(predictions=decoded_preds, references=[[l] for l in decoded_labels])['score']\n",
+        "    chrf_score = chrf.compute(predictions=decoded_preds, references=decoded_labels)['score']\n",
+        "    return {'bleu': bleu_score, 'chrf': chrf_score}\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "3dabbc7a",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "from transformers import Seq2SeqTrainer\n",
+        "\n",
+        "trainer = Seq2SeqTrainer(\n",
+        "    model=model,\n",
+        "    args=training_args,\n",
+        "    train_dataset=processed_ds['train'],\n",
+        "    eval_dataset=processed_ds['validation'],\n",
+        "    tokenizer=tokenizer,\n",
+        "    data_collator=data_collator,\n",
+        "    compute_metrics=compute_metrics,\n",
+        ")\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8fd23984",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "trainer.train()\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "23473f51",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "metrics = trainer.evaluate(processed_ds['test'])\n",
+        "print('Test set metrics:', metrics)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c937d8a9",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "\n",
+        "model_save_path = model_dir / 'nllb-tooro'\n",
+        "trainer.save_model(str(model_save_path))\n",
+        "tokenizer.save_pretrained(str(model_save_path))\n",
+        "print('Model and tokenizer saved to', model_save_path)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import shutil\n",
+        "ZIP_PATH = model_save_path.with_suffix('.zip')\n",
+        "shutil.make_archive(str(model_save_path), 'zip', str(model_save_path))\n",
+        "print(f'Zipped model to: {ZIP_PATH}')\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from google.colab import files\n",
+        "files.download(str(ZIP_PATH))\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from transformers import AutoTokenizer, AutoModelForSeq2SeqLM\n",
+        "local_model_path = '/path/to/unzipped/model'  # replace with actual path\n",
+        "tokenizer = AutoTokenizer.from_pretrained(local_model_path)\n",
+        "model = AutoModelForSeq2SeqLM.from_pretrained(local_model_path)\n",
+        "text = 'Hello world'\n",
+        "inputs = tokenizer(text, return_tensors='pt')\n",
+        "translated_tokens = model.generate(**inputs, forced_bos_token_id=tokenizer.lang_code_to_id.get('ttj_Latn'))\n",
+        "print(tokenizer.decode(translated_tokens[0], skip_special_tokens=True))\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "id": "32748a9f",
-   "metadata": {},
-   "source": [
-    "# NLLB-200 Tooro-English Fine-tuning\n",
-    "This notebook trains `facebook/nllb-200-distilled-600M` for Tooro↔English translation using the HuggingFace ecosystem. Each step prints useful info to help with debugging."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db7d0fd3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "# Install required libraries\n",
-    "!pip install -U transformers datasets evaluate sacrebleu > /dev/null\n",
-    "print('Installed libraries.')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8ad9ac73",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from google.colab import drive\n",
-    "\n",
-    "# Mount drive for persistent storage\n",
-    "try:\n",
-    "    drive.mount('/content/drive')\n",
-    "except Exception as e:\n",
-    "    print('Drive mount failed:', e)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "adeaba1e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from pathlib import Path\n",
-    "\n",
-    "data_dir = Path('/content/drive/MyDrive/rutooro-mt-data')\n",
-    "model_dir = Path('/content/drive/MyDrive/rutooro-mt-models')\n",
-    "output_dir = Path('/content/drive/MyDrive/rutooro-mt-outputs')\n",
-    "\n",
-    "for p in [data_dir, model_dir, output_dir]:\n",
-    "    p.mkdir(parents=True, exist_ok=True)\n",
-    "\n",
-    "print('Data directory:', data_dir)\n",
-    "print('Model directory:', model_dir)\n",
-    "print('Output directory:', output_dir)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b0741f2d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from datasets import load_dataset\n",
-    "\n",
-    "try:\n",
-    "    raw_ds = load_dataset('michsethowusu/english-tooro_sentence-pairs_mt560')\n",
-    "    print('Loaded dataset from HuggingFace.')\n",
-    "except Exception as e:\n",
-    "    print('Failed to load from Hub:', e)\n",
-    "    local_path = data_dir / 'english_rutooro.json'\n",
-    "    if local_path.exists():\n",
-    "        raw_ds = load_dataset('json', data_files=str(local_path))\n",
-    "        print('Loaded dataset from', local_path)\n",
-    "    else:\n",
-    "        raise RuntimeError('Dataset not found. Please upload the data.')\n",
-    "\n",
-    "print(raw_ds)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22ca0fa3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "# Ensure train/val/test splits exist\n",
-    "if 'train' not in raw_ds:\n",
-    "    raw_ds = raw_ds['train'].train_test_split(test_size=0.2)\n",
-    "    raw_ds['validation'] = raw_ds['test'].train_test_split(test_size=0.5)['test']\n",
-    "    raw_ds['test'] = raw_ds['test'].train_test_split(test_size=0.5)['train']\n",
-    "print(raw_ds)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f76e5b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "# Map possible column names to 'eng' and 'ttj'\n",
-    "def map_columns(example):\n",
-    "    en = example.get('english') or example.get('source') or example.get('eng')\n",
-    "    tt = example.get('rutooro') or example.get('target') or example.get('ttj') or example.get('tt')\n",
-    "    return {'eng': en, 'ttj': tt}\n",
-    "\n",
-    "raw_ds = raw_ds.map(map_columns, remove_columns=raw_ds['train'].column_names)\n",
-    "\n",
-    "# Filter out empty rows\n",
-    "raw_ds = raw_ds.filter(lambda x: x['eng'] and x['ttj'])\n",
-    "\n",
-    "print('After filtering:', raw_ds)\n",
-    "print('Sample:', raw_ds['train'][0])\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "94832844",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from transformers import AutoTokenizer, AutoModelForSeq2SeqLM\n",
-    "\n",
-    "model_name = 'facebook/nllb-200-distilled-600M'\n",
-    "tokenizer = AutoTokenizer.from_pretrained(model_name)\n",
-    "model = AutoModelForSeq2SeqLM.from_pretrained(model_name)\n",
-    "\n",
-    "print('Tokenizer language codes:', tokenizer.lang_code_to_id.get('eng_Latn'), tokenizer.lang_code_to_id.get('ttj_Latn'))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "59dcb6d2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "max_length = 128\n",
-    "\n",
-    "def preprocess(example):\n",
-    "    if isinstance(example['eng'], list):\n",
-    "        eng = example['eng']\n",
-    "        ttj = example['ttj']\n",
-    "    else:\n",
-    "        eng = [example['eng']]\n",
-    "        ttj = [example['ttj']]\n",
-    "\n",
-    "    tokenizer.src_lang = 'eng_Latn'\n",
-    "    tokenizer.tgt_lang = 'ttj_Latn'\n",
-    "\n",
-    "    model_inputs = tokenizer(eng, text_target=ttj, max_length=max_length, truncation=True)\n",
-    "    return model_inputs\n",
-    "\n",
-    "processed_ds = raw_ds.map(preprocess, batched=True)\n",
-    "\n",
-    "print(processed_ds)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "09df16df",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from transformers import DataCollatorForSeq2Seq\n",
-    "\n",
-    "data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "bb513e5b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from transformers import Seq2SeqTrainingArguments\n",
-    "\n",
-    "training_args = Seq2SeqTrainingArguments(\n",
-    "    output_dir=str(output_dir),\n",
-    "    evaluation_strategy='epoch',\n",
-    "    save_strategy='epoch',\n",
-    "    learning_rate=2e-5,\n",
-    "    per_device_train_batch_size=4,\n",
-    "    per_device_eval_batch_size=4,\n",
-    "    num_train_epochs=3,\n",
-    "    weight_decay=0.01,\n",
-    "    logging_dir=str(output_dir / 'logs'),\n",
-    "    predict_with_generate=True,\n",
-    "    remove_unused_columns=False,\n",
-    ")\n",
-    "print(training_args)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f082de9d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "import evaluate\n",
-    "\n",
-    "bleu = evaluate.load('sacrebleu')\n",
-    "chrf = evaluate.load('chrf')\n",
-    "\n",
-    "def compute_metrics(eval_preds):\n",
-    "    preds, labels = eval_preds\n",
-    "    if isinstance(preds, tuple):\n",
-    "        preds = preds[0]\n",
-    "    decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)\n",
-    "    labels = [[(l if l != -100 else tokenizer.pad_token_id) for l in label] for label in labels]\n",
-    "    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)\n",
-    "    bleu_score = bleu.compute(predictions=decoded_preds, references=[[l] for l in decoded_labels])['score']\n",
-    "    chrf_score = chrf.compute(predictions=decoded_preds, references=decoded_labels)['score']\n",
-    "    return {'bleu': bleu_score, 'chrf': chrf_score}\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3dabbc7a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "from transformers import Seq2SeqTrainer\n",
-    "\n",
-    "trainer = Seq2SeqTrainer(\n",
-    "    model=model,\n",
-    "    args=training_args,\n",
-    "    train_dataset=processed_ds['train'],\n",
-    "    eval_dataset=processed_ds['validation'],\n",
-    "    tokenizer=tokenizer,\n",
-    "    data_collator=data_collator,\n",
-    "    compute_metrics=compute_metrics,\n",
-    ")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8fd23984",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "trainer.train()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23473f51",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "metrics = trainer.evaluate(processed_ds['test'])\n",
-    "print('Test set metrics:', metrics)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c937d8a9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "model_save_path = model_dir / 'nllb-tooro'\n",
-    "trainer.save_model(str(model_save_path))\n",
-    "print('Model saved to', model_save_path)\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- Save tokenizer alongside model after training
- Add cells to archive the model, download the zip, and demonstrate local loading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dcc9862d8832bb2a188be2befc079